### PR TITLE
imp(evm): PreExecuteCallback for Call opcodes

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -203,6 +203,10 @@ func (evm *EVM) Precompile(addr common.Address) (PrecompiledContract, bool) {
 	return p, ok
 }
 
+func (evm *EVM) GetPrecompiles() ([]common.Address, map[common.Address]PrecompiledContract) {
+	return evm.activePrecompiles, evm.precompiles
+}
+
 // WithPrecompiles sets the precompiled contracts and the slice of actives precompiles.
 // IMPORTANT: This function does NOT validate the precompiles provided to the EVM. The caller should
 // use the ValidatePrecompiles function for this purpose prior to calling WithPrecompiles.

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -203,10 +203,6 @@ func (evm *EVM) Precompile(addr common.Address) (PrecompiledContract, bool) {
 	return p, ok
 }
 
-func (evm *EVM) GetPrecompiles() ([]common.Address, map[common.Address]PrecompiledContract) {
-	return evm.activePrecompiles, evm.precompiles
-}
-
 // WithPrecompiles sets the precompiled contracts and the slice of actives precompiles.
 // IMPORTANT: This function does NOT validate the precompiles provided to the EVM. The caller should
 // use the ValidatePrecompiles function for this purpose prior to calling WithPrecompiles.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -141,9 +141,9 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 	return evm
 }
 
-// NewEVM returns a new EVM. The returned EVM is not thread safe and should
-// only ever be used *once*.
-func NewEVM2(callback preExecuteCallbackType, blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
+// NewEVMWithCallback returns a new EVM and takes a custom preExecuteCallback. The returned EVM is
+// not thread safe and should only ever be used *once*.
+func NewEVMWithCallback(callback preExecuteCallbackType, blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
 	evm := &EVM{
 		Context:            blockCtx,
 		TxContext:          txCtx,

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -109,18 +109,49 @@ type EVM struct {
 	precompiles map[common.Address]PrecompiledContract
 	// activePrecompiles defines the precompiles that are currently active
 	activePrecompiles []common.Address
+
+	// preExecuteCallback is a callback function that is called before executing
+	// CALL, CALLCODE, DELEGATECALL and STATICCALL opcodes.
+	preExecuteCallback preExecuteCallbackType
+}
+
+type preExecuteCallbackType func(evm *EVM, addr common.Address) error
+
+func dummyCallback(evm *EVM, addr common.Address) error {
+	return nil
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
 func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
 	evm := &EVM{
-		Context:     blockCtx,
-		TxContext:   txCtx,
-		StateDB:     statedb,
-		Config:      config,
-		chainConfig: chainConfig,
-		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil),
+		Context:            blockCtx,
+		TxContext:          txCtx,
+		StateDB:            statedb,
+		Config:             config,
+		chainConfig:        chainConfig,
+		chainRules:         chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil),
+		preExecuteCallback: dummyCallback,
+	}
+	// set the default precompiles
+	evm.activePrecompiles = DefaultActivePrecompiles(evm.chainRules)
+	evm.precompiles = DefaultPrecompiles(evm.chainRules)
+	evm.interpreter = NewEVMInterpreter(evm, config)
+
+	return evm
+}
+
+// NewEVM returns a new EVM. The returned EVM is not thread safe and should
+// only ever be used *once*.
+func NewEVM2(callback preExecuteCallbackType, blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
+	evm := &EVM{
+		Context:            blockCtx,
+		TxContext:          txCtx,
+		StateDB:            statedb,
+		Config:             config,
+		chainConfig:        chainConfig,
+		chainRules:         chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil),
+		preExecuteCallback: callback,
 	}
 	// set the default precompiles
 	evm.activePrecompiles = DefaultActivePrecompiles(evm.chainRules)
@@ -158,11 +189,22 @@ func (evm *EVM) WithInterpreter(interpreter Interpreter) {
 	evm.interpreter = interpreter
 }
 
+type callBack func(addr common.Address, evm *EVM) error
+
+type ExtensionCaller interface {
+	ContractRef
+}
+
 // Call executes the contract associated with the addr with the given input as
 // parameters. It also handles any necessary value transfer required and takes
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	err = evm.preExecuteCallback(evm, addr)
+	if err != nil {
+		return nil, gas, err
+	}
+
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth
@@ -171,6 +213,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	if value.Sign() != 0 && !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
 		return nil, gas, ErrInsufficientBalance
 	}
+
 	snapshot := evm.StateDB.Snapshot()
 	p, isPrecompile := evm.Precompile(addr)
 
@@ -250,6 +293,11 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 // CallCode differs from Call in the sense that it executes the given address'
 // code with the caller as context.
 func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	err = evm.preExecuteCallback(evm, addr)
+	if err != nil {
+		return nil, gas, err
+	}
+
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth
@@ -298,6 +346,11 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 // DelegateCall differs from CallCode in the sense that it executes the given address'
 // code with the caller as context and the caller is set to the caller of the caller.
 func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	err = evm.preExecuteCallback(evm, addr)
+	if err != nil {
+		return nil, gas, err
+	}
+
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth
@@ -337,6 +390,11 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 // Opcodes that attempt to perform such modifications will result in exceptions
 // instead of performing the modifications.
 func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	err = evm.preExecuteCallback(evm, addr)
+	if err != nil {
+		return nil, gas, err
+	}
+
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -143,7 +143,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
-func NewEVM2(callBack preExecuteCallbackType, blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
+func NewEVM2(callback preExecuteCallbackType, blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
 	evm := &EVM{
 		Context:            blockCtx,
 		TxContext:          txCtx,
@@ -151,7 +151,7 @@ func NewEVM2(callBack preExecuteCallbackType, blockCtx BlockContext, txCtx TxCon
 		Config:             config,
 		chainConfig:        chainConfig,
 		chainRules:         chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil),
-		preExecuteCallback: callBack,
+		preExecuteCallback: callback,
 	}
 	// set the default precompiles
 	evm.activePrecompiles = DefaultActivePrecompiles(evm.chainRules)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -143,7 +143,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
-func NewEVM2(callback preExecuteCallbackType, blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
+func NewEVM2(callBack preExecuteCallbackType, blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
 	evm := &EVM{
 		Context:            blockCtx,
 		TxContext:          txCtx,
@@ -151,7 +151,7 @@ func NewEVM2(callback preExecuteCallbackType, blockCtx BlockContext, txCtx TxCon
 		Config:             config,
 		chainConfig:        chainConfig,
 		chainRules:         chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil),
-		preExecuteCallback: callback,
+		preExecuteCallback: callBack,
 	}
 	// set the default precompiles
 	evm.activePrecompiles = DefaultActivePrecompiles(evm.chainRules)
@@ -187,12 +187,6 @@ func (evm *EVM) Interpreter() Interpreter {
 // WithInterpreter sets the interpreter to the EVM instance
 func (evm *EVM) WithInterpreter(interpreter Interpreter) {
 	evm.interpreter = interpreter
-}
-
-type callBack func(addr common.Address, evm *EVM) error
-
-type ExtensionCaller interface {
-	ContractRef
 }
 
 // Call executes the contract associated with the addr with the given input as

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -1,18 +1,5 @@
-// Copyright 2014 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
 
 package vm
 


### PR DESCRIPTION
PR that adds the possibility of adding a callback function to the EVM struct. This callback will be called on all of the `Call` opcodes. 

Closes [EVM-83](https://linear.app/altiplanic/issue/EVM-83/add-license-change-to-the-pr-of-freddy)